### PR TITLE
Catch goals with the extension .org

### DIFF
--- a/.github/workflows/milestones-issues.yml
+++ b/.github/workflows/milestones-issues.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     paths:
       - 'proyectos/hito-[1234567].md'
-      - '!objetivos/*.md'
+      - '!objetivos/*.(md|org)'
 
 jobs:
   obtain-repo:
@@ -19,4 +19,3 @@ jobs:
         with:
           github-token: ${{github.token}}
           minMilestones: 3
-

--- a/objetivos/iris-garcia.org
+++ b/objetivos/iris-garcia.org
@@ -1,6 +1,7 @@
 * Iris Garcia's Goals per session
 - [[#session-1][Session 01]]
 - [[#session-2][Session 02]]
+- [[#session-3][Session 03]]
 
 * Session 01
 - [X] Gather all the given resources for the subject and bookmark them.
@@ -19,4 +20,14 @@
 - [X] Read and understand the [[http://jj.github.io/IV/documentos/temas/Intro_concepto_y_soporte_fisico#introduccin][resource]] given for this session.
 - [X] Create a new repository to host the proposed exercises.
 - [X] Do and document the exercises 1-6.
-- [ ] Elaborate the description of the [[https://github.com/iris-garcia/webhooks-handler][project]] as suggested by [[https://github.com/JJ][JJ]].
+- [X] Elaborate the description of the [[https://github.com/iris-garcia/webhooks-handler][project]] as suggested by [[https://github.com/JJ][JJ]].
+
+* Session 03
+- [ ] Understand the requirements for the [[http://jj.github.io/IV/documentos/proyecto/1.Infraestructura][milestone 1]].
+- [ ] Understand the JSON format and its utility.
+- [ ] Install the required tools/libraries to properly test a project.
+- [ ] Use different virtual environments of some programming languages.
+- [ ] Understand what are the goals and how to elaborate them properly.
+- [ ] Complete the [[http://jj.github.io/IV/documentos/proyecto/1.Infraestructura][milestone 1]] before September 30 13:30.
+- [ ] Read the [[http://jj.github.io/IV/documentos/temas/Desarrollo_basado_en_pruebas][resource]] given for this session.
+- [ ] Do and document the exercises 1-10.

--- a/objetivos/iris-garcia.org
+++ b/objetivos/iris-garcia.org
@@ -1,5 +1,6 @@
 * Iris Garcia's Goals per session
 - [[#session-1][Session 01]]
+- [[#session-2][Session 02]]
 
 * Session 01
 - [X] Gather all the given resources for the subject and bookmark them.
@@ -13,3 +14,9 @@
 - [X] Complete the [[http://jj.github.io/IV/documentos/proyecto/0.Repositorio][milestone 0]].
 - [X] Understand the importance of the Open Source.
 - [X] Join the new [[https://t.me/joinchat/AOR8MhHP5uoG4d1WZUTbag][Telegram group]].
+
+* Session 02
+- [ ] Read and understand the [[http://jj.github.io/IV/documentos/temas/Intro_concepto_y_soporte_fisico#introduccin][resource]] given for this session.
+- [ ] Create a new repository to host the proposed exercises.
+- [ ] Do and document the exercises 1-6.
+- [ ] Elaborate the description of the [[https://github.com/iris-garcia/webhooks-handler][project]] as suggested by [[https://github.com/JJ][JJ]].

--- a/objetivos/iris-garcia.org
+++ b/objetivos/iris-garcia.org
@@ -18,5 +18,5 @@
 * Session 02
 - [X] Read and understand the [[http://jj.github.io/IV/documentos/temas/Intro_concepto_y_soporte_fisico#introduccin][resource]] given for this session.
 - [X] Create a new repository to host the proposed exercises.
-- [ ] Do and document the exercises 1-6.
+- [X] Do and document the exercises 1-6.
 - [ ] Elaborate the description of the [[https://github.com/iris-garcia/webhooks-handler][project]] as suggested by [[https://github.com/JJ][JJ]].

--- a/objetivos/iris-garcia.org
+++ b/objetivos/iris-garcia.org
@@ -16,7 +16,7 @@
 - [X] Join the new [[https://t.me/joinchat/AOR8MhHP5uoG4d1WZUTbag][Telegram group]].
 
 * Session 02
-- [ ] Read and understand the [[http://jj.github.io/IV/documentos/temas/Intro_concepto_y_soporte_fisico#introduccin][resource]] given for this session.
-- [ ] Create a new repository to host the proposed exercises.
+- [X] Read and understand the [[http://jj.github.io/IV/documentos/temas/Intro_concepto_y_soporte_fisico#introduccin][resource]] given for this session.
+- [X] Create a new repository to host the proposed exercises.
 - [ ] Do and document the exercises 1-6.
 - [ ] Elaborate the description of the [[https://github.com/iris-garcia/webhooks-handler][project]] as suggested by [[https://github.com/JJ][JJ]].


### PR DESCRIPTION
With the current GitHub workflow only the goals with extension .md are catch.
I didn't test this change, so please double check the change.