### PR TITLE
Allows goals with the extension .org.

### DIFF
--- a/.github/workflows/milestones-issues.yml
+++ b/.github/workflows/milestones-issues.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     paths:
       - 'proyectos/hito-[1234567].md'
-      - '!objetivos/*.md'
+      - '!objetivos/*.(md|org)'
 
 jobs:
   obtain-repo:
@@ -19,4 +19,3 @@ jobs:
         with:
           github-token: ${{github.token}}
           minMilestones: 3
-


### PR DESCRIPTION
Currently the GitHub workflow only checks for goals with the extension `.md`. This pull request allows also the extension `.org`.